### PR TITLE
Fix the servlet response to fit the RepoElement structure

### DIFF
--- a/MokapBackend/src/es/eucm/mokap/backend/model/response/SearchResponse.java
+++ b/MokapBackend/src/es/eucm/mokap/backend/model/response/SearchResponse.java
@@ -12,10 +12,10 @@ public class SearchResponse extends Response {
 	
 	private String message;
 	private String searchCursor;
-	private List<Map<String,String>> results = new LinkedList<Map<String,String>>();
+	private List<Map<String,Object>> results = new LinkedList<Map<String,Object>>();
 	
-	public void addResult(Map<String, String> res){
-		this.results.add(res);
+	public void addResult(Map<String, Object> ent){
+		this.results.add(ent);
 	}
 	
 	public int getCount() {
@@ -24,10 +24,10 @@ public class SearchResponse extends Response {
 	public void setCount(int count) {
 		this.count = count;
 	}
-	public List<Map<String, String>> getResults() {
+	public List<Map<String, Object>> getResults() {
 		return results;
 	}
-	public void setResults(List<Map<String, String>> results) {
+	public void setResults(List<Map<String, Object>> results) {
 		this.results = results;
 	}
 

--- a/MokapBackend/src/es/eucm/mokap/backend/server/MokapBackend.java
+++ b/MokapBackend/src/es/eucm/mokap/backend/server/MokapBackend.java
@@ -108,7 +108,8 @@ public class MokapBackend extends HttpServlet {
 		String searchCursor = req.getParameter("c");
 		
 		SearchResponse gr = ga.searchByString(searchString, searchCursor);
-		String str = new String(Charset.forName("UTF-8").encode(gr.toJsonString()).array());
+		String str = gr.toJsonString();
+		//String str = new String(Charset.forName("UTF-8").encode(gr.toJsonString()).array());
 		
 		out.print(str);
 		out.flush();
@@ -161,7 +162,7 @@ public class MokapBackend extends HttpServlet {
 				content != null
 					){
 					// Analizar json
-					Map<String, String> entMap = Utils.jsonToMap(descriptor);
+					Map<String, Object> entMap = Utils.jsonToMap(descriptor);
 					// Parse the map into an entity
 					Entity ent = new Entity("Resource");			    
 					for(String key :entMap.keySet()){
@@ -191,6 +192,15 @@ public class MokapBackend extends HttpServlet {
 		}catch(Exception e){
 			e.printStackTrace();
 			assignedKeyId = 0;
+			//Force rollback if anything failed
+			try{
+				ga.deleteFile(tempFileName);
+				for(String key : tns.keySet()){
+					ByteArrayInputStream imgs = new ByteArrayInputStream(tns.get(key)); 
+					ga.deleteFile(assignedKeyId+"/"+key);
+				}
+				ga.deleteEntity(assignedKeyId);
+			}catch(Exception ex){}
 		}
 		return assignedKeyId;
 	}

--- a/MokapBackend/src/es/eucm/mokap/backend/utils/GoogleAccess.java
+++ b/MokapBackend/src/es/eucm/mokap/backend/utils/GoogleAccess.java
@@ -192,7 +192,7 @@ public class GoogleAccess {
 			try{
 			long keyId = Long.parseLong(sd.getOnlyField("entityRef").getText());
 			
-			Map<String, String> ent = getEntityById(keyId);
+			Map<String, Object> ent = getEntityById(keyId);
 			prepareResponseEntity(keyId, ent);
 			
 			gr.addResult(ent);
@@ -213,24 +213,24 @@ public class GoogleAccess {
 	 * @throws IOException
 	 */
 	private void prepareResponseEntity(long keyId,
-			Map<String, String> ent) throws IOException {
+			Map<String, Object> ent) throws IOException {
 		ent.put("entityRef", keyId+"");
 		ent.put("contentsUrl", DOWNLOAD_URL+keyId+".zip");
 		List<String> tnsUrls = getTnsUrls(keyId);			
-		List<String> tnsWidths = new LinkedList<String>();
-		List<String> tnsHeights = new LinkedList<String>();
+		List<Integer> tnsWidths = new LinkedList<Integer>();
+		List<Integer> tnsHeights = new LinkedList<Integer>();
 		for(String tn : tnsUrls){
 			int lastSeparator = tn.lastIndexOf("/")+1;							
 			String end = tn.substring(lastSeparator);			
 			String res = end.split("\\.")[0];			
 			String[] resolutionParams = res.split("x");			
-			tnsWidths.add(resolutionParams[0]);
-			tnsHeights.add(resolutionParams[1]);			
+			tnsWidths.add(Integer.parseInt(resolutionParams[0]));
+			tnsHeights.add(Integer.parseInt(resolutionParams[1]));			
 		}
 		
-		ent.put("thumbnailUrlList", tnsUrls.toString());
-		ent.put("thumbnailWidthList", tnsWidths.toString());
-		ent.put("thumbnailHeightList", tnsHeights.toString());
+		ent.put("thumbnailUrlList", tnsUrls);
+		ent.put("thumbnailWidthList", tnsWidths);
+		ent.put("thumbnailHeightList", tnsHeights);
 		
 	}
 	/**
@@ -257,8 +257,8 @@ public class GoogleAccess {
 	 * @param keyId
 	 * @return
 	 */
-	public Map<String,String> getEntityById(long keyId) {
-		Map<String,String> m = new HashMap<String,String>();
+	public Map<String, Object> getEntityById(long keyId) {
+		Map<String,Object> m = new HashMap<String,Object>();
 		
 		Key k = KeyFactory.createKey("Resource", keyId);
 		Filter keyFilter =
@@ -270,7 +270,7 @@ public class GoogleAccess {
 		if(result != null){
 			Map<String,Object> props = result.getProperties();
 			for(String key : props.keySet())
-				m.put(key, props.get(key).toString());
+				m.put(key, props.get(key));
 		}
 		return m;
 	}
@@ -281,5 +281,13 @@ public class GoogleAccess {
 	 */
 	public Key storeEntity(Entity ent) {
 		return ds.put(ent);
+	}
+	/**
+	 * Deletes an entity from Google Datastore
+	 * @param assignedKeyId
+	 */
+	public void deleteEntity(long keyId) {
+		Key k = KeyFactory.createKey("Resource", keyId);
+		ds.delete(k);		
 	}
 }

--- a/MokapBackend/src/es/eucm/mokap/backend/utils/Utils.java
+++ b/MokapBackend/src/es/eucm/mokap/backend/utils/Utils.java
@@ -26,12 +26,12 @@ public class Utils {
 	 * @throws JsonSyntaxException
 	 */
 	@SuppressWarnings("unchecked")
-	public static Map<String, String> jsonToMap(String jsonString)
+	public static Map<String, Object> jsonToMap(String jsonString)
 			throws JsonSyntaxException {
 		// Convert the JSON into a Map
 		Gson gson = new GsonBuilder().create();		
-		Map<String,String> entMap = new HashMap<String,String>();
-		entMap = (HashMap<String,String>) gson.fromJson(jsonString, entMap.getClass() );		
+		Map<String,Object> entMap = new HashMap<String,Object>();
+		entMap = (HashMap<String,Object>) gson.fromJson(jsonString, entMap.getClass() );		
 		
 		return entMap;
 	}


### PR DESCRIPTION
-Changed the Maps from String,String to String,Object:
This should fix the issues converting the servlet response to a RepoElement object.
Later on we might change the Map(String,Object) to RepoElement objects.
-Changed the way we parse the SearchResponse when sending it to the client. It was being parsed as a byte stream, now it's a simple String.
